### PR TITLE
Changes:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@highlightjs/vue-plugin": "^2.1.0",
-        "@i4mi/fhir_r4": "^1.0.10",
-        "@i4mi/js-on-fhir": "^0.2.1",
+        "@i4mi/fhir_r4": "2.0.0",
+        "@i4mi/js-on-fhir": "^1.0.0-beta.13",
         "@quasar/extras": "^1.0.0",
         "core-js": "^3.6.5",
         "highlight.js": "^11.3.1",
@@ -1803,19 +1803,28 @@
       "dev": true
     },
     "node_modules/@i4mi/fhir_r4": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@i4mi/fhir_r4/-/fhir_r4-1.0.10.tgz",
-      "integrity": "sha512-mA1wsAuUqbJCCkWuRKmnXpdc0I2xJCNIdqQGft7JDD7YES3R7xR9khifH7Rt3IRwtsYj/H9FOUvPRK0PoBEx9g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@i4mi/fhir_r4/-/fhir_r4-2.0.0.tgz",
+      "integrity": "sha512-7Wi9CCgopM2XNGHYomyUP+BgOhXJRJD4ewIXjzuNzDWy0vbnkt1xV01s+P3Vi2dTRufBJFXUxkXKmc/EXUxz6g==",
       "dependencies": {
         "guid-typescript": "^1.0.9"
       }
     },
     "node_modules/@i4mi/js-on-fhir": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@i4mi/js-on-fhir/-/js-on-fhir-0.2.1.tgz",
-      "integrity": "sha512-AlNuZB2epfkiosh7pkv1UGtQAvKYmcreOFCN/KaNDyebRYMlO7pVLX6DQXN8MhnxE5YOPYj42DUEcsgBD2mB4g==",
+      "version": "1.0.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@i4mi/js-on-fhir/-/js-on-fhir-1.0.0-beta.13.tgz",
+      "integrity": "sha512-Ws2T0BKc0NeVJfOGZFP4nY+jXI8uIwD6jmQrmpuJMtqm6knyFZHmsKmWwJCsNR/vUhRqbINSUImbPFCMKJQa2g==",
       "dependencies": {
-        "@i4mi/fhir_r4": "^1.0.10"
+        "@i4mi/fhir_r4": "^2.0.0",
+        "node-forge": "^1.3.1"
+      }
+    },
+    "node_modules/@i4mi/js-on-fhir/node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/@intlify/core-base": {
@@ -12970,19 +12979,27 @@
       "dev": true
     },
     "@i4mi/fhir_r4": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@i4mi/fhir_r4/-/fhir_r4-1.0.10.tgz",
-      "integrity": "sha512-mA1wsAuUqbJCCkWuRKmnXpdc0I2xJCNIdqQGft7JDD7YES3R7xR9khifH7Rt3IRwtsYj/H9FOUvPRK0PoBEx9g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@i4mi/fhir_r4/-/fhir_r4-2.0.0.tgz",
+      "integrity": "sha512-7Wi9CCgopM2XNGHYomyUP+BgOhXJRJD4ewIXjzuNzDWy0vbnkt1xV01s+P3Vi2dTRufBJFXUxkXKmc/EXUxz6g==",
       "requires": {
         "guid-typescript": "^1.0.9"
       }
     },
     "@i4mi/js-on-fhir": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@i4mi/js-on-fhir/-/js-on-fhir-0.2.1.tgz",
-      "integrity": "sha512-AlNuZB2epfkiosh7pkv1UGtQAvKYmcreOFCN/KaNDyebRYMlO7pVLX6DQXN8MhnxE5YOPYj42DUEcsgBD2mB4g==",
+      "version": "1.0.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@i4mi/js-on-fhir/-/js-on-fhir-1.0.0-beta.13.tgz",
+      "integrity": "sha512-Ws2T0BKc0NeVJfOGZFP4nY+jXI8uIwD6jmQrmpuJMtqm6knyFZHmsKmWwJCsNR/vUhRqbINSUImbPFCMKJQa2g==",
       "requires": {
-        "@i4mi/fhir_r4": "^1.0.10"
+        "@i4mi/fhir_r4": "^2.0.0",
+        "node-forge": "^1.3.1"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+          "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+        }
       }
     },
     "@intlify/core-base": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@highlightjs/vue-plugin": "^2.1.0",
-    "@i4mi/fhir_r4": "^1.0.10",
-    "@i4mi/js-on-fhir": "^0.2.1",
+    "@i4mi/fhir_r4": "2.0.0",
+    "@i4mi/js-on-fhir": "^1.0.0-beta.13",
     "@quasar/extras": "^1.0.0",
     "core-js": "^3.6.5",
     "highlight.js": "^11.3.1",

--- a/src/plugins/storage.ts
+++ b/src/plugins/storage.ts
@@ -205,7 +205,7 @@ export default class Storage {
    * @param _id
    */
   public setCurrentObservation(_id: string): void {
-    void this.midata.search('Observation/' + _id).then((result) => {
+    void this.midata.searchWithId('Observation', _id).then((result) => {
       this.currentObservation = result as Observation;
       this.persist();
     });


### PR DESCRIPTION
-@i4mi/fhir_r4 version 1.0.10 --> 2.0.0
-@i4mi/js-on-fhir version 0.2.1 --> 1.0.0-beta.13

Fixes:
storage.ts
-setCurrentObservation now uses the new searchWithId function of the midataService.ts class and can only return a single resource.

midataService.ts
-searchWithId function implemented. New version of the search function that uses the id to only return one resource max. The search function is now not used anymore -Different small changes because the @i4mi/js-on-fhir package was updated and now uses typed return values. For example the getPatientResource method uses the jsOnFhir.getResource method now instead of jsOnFhir.search